### PR TITLE
Configure remote access via environment variable 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,12 @@ RUN apt-get update \
   && bash ./install_dependencies.sh \
   && popd || exit
 
+RUN apt install -y curl supervisor jq 
+COPY supervisor.conf /etc/supervisor/conf.d/
+COPY api-configuration.sh /
 
-EXPOSE 80/tcp
+ENTRYPOINT ["/usr/bin/supervisord"]
+CMD ["-n", "-c", "/etc/supervisor/supervisord.conf"]
 
-ENTRYPOINT ["/opt/acestream/start-engine"]
-CMD ["--client-console", "--http-port", "80"]
+EXPOSE 6878/tcp
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get update \
 RUN apt install -y curl supervisor jq 
 COPY supervisor.conf /etc/supervisor/conf.d/
 COPY api-configuration.sh /
+ENV ALLOW_REMOTE_ACCESS="no"
 
 ENTRYPOINT ["/usr/bin/supervisord"]
 CMD ["-n", "-c", "/etc/supervisor/supervisord.conf"]

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Note: ARM-based CPUs are not currently supported, see issues [#5] and [#13].
 Ensure you have [Docker](https://www.docker.com) installed and running. You can then pull down and run the container as shown below.
 
 ```console
-docker run -t -p 80:80 ghcr.io/martinbjeldbak/acestream-http-proxy
+docker run -t -p 6878:6878 martinbjeldbak/acestream-http-proxy
 ```
 
 You are then able to access AceStreams by pointing your favorite media player
@@ -28,19 +28,19 @@ streaming protocol.
 
 For HLS:
 ```console
-http://127.0.0.1/ace/manifest.m3u8?id=dd1e67078381739d14beca697356ab76d49d1a2
+http://127.0.0.1:6878/ace/manifest.m3u8?id=dd1e67078381739d14beca697356ab76d49d1a2
 ```
 
 For MPEG-TS:
 
 ```console
-http://127.0.0.1/ace/getstream?id=dd1e67078381739d14beca697356ab76d49d1a2
+http://127.0.0.1:6878/ace/getstream?id=dd1e67078381739d14beca697356ab76d49d1a2
 ```
 
 where `dd1e67078381739d14beca697356ab76d49d1a2d` is the ID of the AceStream channel.
 
 This image can also be deployed to a server, where it can proxy AceStream
-content over HTTP.
+content over HTTP. To able to reach it from remote you need to set ALLOW_REMOTE_ACCESS=yes as environment variable  
 
 ## Contributing
 

--- a/api-configuration.sh
+++ b/api-configuration.sh
@@ -1,0 +1,13 @@
+#wait until engine start
+sleep 10
+
+# Initial request to get the API access token
+response=$(curl -s "http://localhost:6878/server/api?api_version=3&method=get_api_access_token")
+
+# Parse the token from the JSON response
+token=$(echo $response | jq -r '.result.token')
+
+if [[ $ALLOW_REMOTE_ACCESS == "yes" ]];then
+    # Use the token in the next request to enable remote access
+    curl "http://localhost:6878/server/api?api_version=3&method=set_allow_remote_access&token=$token&value=1"
+fi

--- a/api-configuration.sh
+++ b/api-configuration.sh
@@ -1,13 +1,13 @@
-#wait until engine start
-sleep 10
-
-# Initial request to get the API access token
-response=$(curl -s "http://localhost:6878/server/api?api_version=3&method=get_api_access_token")
-
-# Parse the token from the JSON response
-token=$(echo $response | jq -r '.result.token')
-
 if [[ $ALLOW_REMOTE_ACCESS == "yes" ]];then
+    #wait until engine start
+    sleep 10
+
+    # Initial request to get the API access token
+    response=$(curl -s "http://localhost:6878/server/api?api_version=3&method=get_api_access_token")
+
+    # Parse the token from the JSON response
+    token=$(echo $response | jq -r '.result.token')
+
     # Use the token in the next request to enable remote access
     curl "http://localhost:6878/server/api?api_version=3&method=set_allow_remote_access&token=$token&value=1"
 fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,4 +3,6 @@ services:
   app:
     build: .
     ports:
-      - '6878:80'
+      - '6878:6878'
+    environment:
+      - ALLOW_REMOTE_ACCESS=no

--- a/supervisor.conf
+++ b/supervisor.conf
@@ -1,0 +1,20 @@
+[program:engine]
+directory: /
+command: /opt/acestream/start-engine --client-console --http-port 6878
+user: root
+priority: 1
+autostart: true
+autorestart: true
+redirect_stderr=true
+stdout_logfile=/var/log/engine.log
+
+[program:api-configuration]
+directory: /
+command: /bin/bash api-configuration.sh
+user: root
+priority: 10
+autorestart = false
+startretries = 0
+startsecs = 0
+redirect_stderr=true
+stdout_logfile=/var/log/api-configuration.log

--- a/supervisor.conf
+++ b/supervisor.conf
@@ -6,7 +6,8 @@ priority: 1
 autostart: true
 autorestart: true
 redirect_stderr=true
-stdout_logfile=/var/log/engine.log
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 
 [program:api-configuration]
 directory: /
@@ -17,4 +18,5 @@ autorestart = false
 startretries = 0
 startsecs = 0
 redirect_stderr=true
-stdout_logfile=/var/log/api-configuration.log
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0


### PR DESCRIPTION
This PR introduces an environment variable that allows configuring remote access. 

It can be set using ALLOW_REMOTE_ACCESS=yes.

I had to use Supervisor because the engine needs to start before sending an API request to enable remote access.
I also changed listen port to default to avoid confusion and updated the document accordingly.

Relates #24 and #22 