### PR TITLE
Fix syntax for EXTRA_FLAGS variable in entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,5 +8,5 @@ fi
 exec \
 	/app/start-engine \
 	--client-console \
-	"$EXTRA_FLAGS" \
+	$EXTRA_FLAGS \
 	"$@"


### PR DESCRIPTION
## Issue

I couldn't get remote access to work - the `ALLOW_REMOTE_ACCESS=yes` environment variable wasn't being recognized and `allow_remote` was always set to 0 in the logs.

## Fix

I found that `$EXTRA_FLAGS` was quoted in the entrypoint script, which prevented the `--bind-all` flag from being passed correctly to the acestream engine. Removing the quotes fixed the issue.

## Testing

After this change, remote access works perfectly:
- Logs now show `allow_remote=1` 
- Can access the API remotely: `http://SERVER_IP:6878/webui/api/service?method=get_version`

Tested on Ubuntu Server 24.04.